### PR TITLE
automake: Add warnings by default

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,7 +17,7 @@
 
 ACLOCAL_AMFLAGS = -I m4
 
-AM_CFLAGS = -Wstrict-prototypes
+AM_CFLAGS = -Wstrict-prototypes -Wall
 AM_CFLAGS += $(WARNING_FLAGS)
 
 ALL_LOCAL =

--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,7 @@ AC_DEFINE([__STDC_LIMIT_MACROS],[1],[C99 requires this define])
 AC_CHECK_LIB([m], [pow])
 AC_CHECK_FUNCS([strchr getchar memset memcmp memcpy])
 ESNACC_CHECK_WIN32
+ESNACC_CHECK_WARNINGS
 AC_CHECK_XSLTPROC
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/m4/warnings.m4
+++ b/m4/warnings.m4
@@ -1,0 +1,40 @@
+# -*- autoconf -*-
+
+dnl Tries to enable -Wall -Wextra on systems which support it.
+AC_DEFUN([ESNACC_CHECK_WARNINGS],
+        [AC_LANG_PUSH([C])
+        AC_MSG_CHECKING(for C-compiler all-warnings support with -Wall)
+        old_CFLAGS="$CFLAGS"
+        CFLAGS="$CFLAGS -Wall"
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],[])],
+          AC_MSG_RESULT(yes),
+          AC_MSG_RESULT(no)
+          CFLAGS="$old_CFLAGS")
+
+        AC_MSG_CHECKING(for C-compiler extra-warnings support with -Wextra)
+        old_CFLAGS="$CFLAGS"
+        CFLAGS="$CFLAGS -Wextra"
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],[])],
+          AC_MSG_RESULT(yes),
+          AC_MSG_RESULT(no)
+          CFLAGS="$old_CFLAGS")
+        AC_LANG_POP()
+
+        AC_LANG_PUSH([C++])
+        AC_MSG_CHECKING(for C++-compiler all-warnings support with -Wall)
+        old_CXXFLAGS="$CXXFLAGS"
+        CXXFLAGS="$CXXFLAGS -Wall"
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],[])],
+          AC_MSG_RESULT(yes),
+          AC_MSG_RESULT(no)
+        CXXFLAGS="$old_CXXFLAGS")
+
+        AC_MSG_CHECKING(for C++-compiler extra-warnings support with -Wextra)
+        old_CXXFLAGS="$CXXFLAGS"
+        CXXFLAGS="$CXXFLAGS -Wextra"
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],[])],
+          AC_MSG_RESULT(yes),
+          AC_MSG_RESULT(no)
+          CXXFLAGS="$old_CXXFLAGS")
+        AC_LANG_POP()
+])


### PR DESCRIPTION
This commit adds a check for -Wall and -Wextra flags. If those flags are
supported in the compiler, they will be enabled by default. This can help to
catch problematic commits early, as well as giving plenty of work to clean
up areas of the code that need attention.

Signed-off-by: Aaron Conole <aconole@bytheb.org>