### PR TITLE
Fix crash when extension is used in child tags

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,7 +32,7 @@ Scott Rankin
 Tom Horvath
 Uri Blumenthal                        uri@mit.edu
 Vladislav Evgeniev
-
+Si Peng                               stiffme@gmail.com
 
 REPORTERS
 =========

--- a/compiler/back-ends/tag-util.c
+++ b/compiler/back-ends/tag-util.c
@@ -10,7 +10,7 @@
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
  *
- * $Header: /baseline/SNACC/compiler/back-ends/tag-util.c,v1.8  2016/08/22  Si Peng Exp $
+ * $Header: /baseline/SNACC/compiler/back-ends/tag-util.c,v 1.8  2016/08/22  Si Peng Exp $
  * $Log: tag-util.c,v $
  * Revision 1.8  2016/08/22  Si Peng
  * Fix a crash when implicit tags are used and child top level tag contains "...".
@@ -89,8 +89,8 @@
  *         foo [0] INTEGER,                          [0] INTEGER,
  *         bar SomeChoice,                           [1] BOOLEAN,
  *         bell [1] IMPLICIT BOOLEAN,                [2] IA5String,
- *         gumby [2] SomeChoice,                }
-           poki SomeOtherChoice
+ *	   gumby [2] SomeChoice,                     ...
+ *         poki SomeOtherChoice			}
  *   }
  *
  *  SomeOtherChoice ::= [APPLICATION 99] CHOICE { ....}

--- a/compiler/back-ends/tag-util.c
+++ b/compiler/back-ends/tag-util.c
@@ -10,8 +10,11 @@
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
  *
- * $Header: /baseline/SNACC/compiler/back-ends/tag-util.c,v 1.7 2003/07/28 11:13:51 colestor Exp $
+ * $Header: /baseline/SNACC/compiler/back-ends/tag-util.c,v1.8  2016/08/22  Si Peng Exp $
  * $Log: tag-util.c,v $
+ * Revision 1.8  2016/08/22  Si Peng
+ * Fix a crash when implicit tags are used and child top level tag contains "...".
+ * 
  * Revision 1.7  2003/07/28 11:13:51  colestor
  * Changes to complete handing of the "--snacc namespace" compiler directive.
  * Also, updates to handle ASN.1 constant integer tag designations for C++/C.
@@ -85,7 +88,7 @@
  *   {                                          {
  *         foo [0] INTEGER,                          [0] INTEGER,
  *         bar SomeChoice,                           [1] BOOLEAN,
- *         bell [1] IMPLICIT BOOLEAN,                [2] IA5String
+ *         bell [1] IMPLICIT BOOLEAN,                [2] IA5String,
  *         gumby [2] SomeChoice,                }
            poki SomeOtherChoice
  *   }

--- a/compiler/back-ends/tag-util.c
+++ b/compiler/back-ends/tag-util.c
@@ -191,7 +191,9 @@ GetTags PARAMS ((t, stoleChoiceTags),
 
                 if (tl == NULL)
                     break;
-
+		if(e->type->basicType->choiceId == BASICTYPE_EXTENSION)
+			continue;
+			
 		          AsnListFirst (tl);
                 if (stoleChoicesAgain)
                 {


### PR DESCRIPTION
Extension type has no tags, this will cause :
tag = (Tag*)FIRST_LIST_ELMT (tl);
crash because there is no element in the list, here is an example:

PrivateExtension ::= SEQUENCE {     
   extId OBJECT IDENTIFIER,
   extType ExtensionType OPTIONAL}
  }

-- All tags added in each Extension Type SHOULD be inspcted by TC-MAP                           
ExtensionType ::= CHOICE {    
   ext-atiArgType [13] Ext-AtiArgType,
 ...}

                            