### PR TITLE
Change EXTERNAL.single-ASN1-type from OCTET STRING to ANY

### DIFF
--- a/asn1specs/asn-useful.asn1
+++ b/asn1specs/asn-useful.asn1
@@ -66,7 +66,7 @@ EXTERNAL         ::= --snacc isPdu:"TRUE" -- [UNIVERSAL 8] IMPLICIT SEQUENCE
         data-value-descriptor ObjectDescriptor OPTIONAL,
         encoding CHOICE
         {
-                single-ASN1-type [0] OCTET STRING,  -- should be ANY
+                single-ASN1-type [0] ANY,
                 octet-aligned    [1] IMPLICIT OCTET STRING,
                 arbitrary        [2] IMPLICIT BIT STRING
         }

--- a/asn1specs/asn-usefulVDA.asn1
+++ b/asn1specs/asn-usefulVDA.asn1
@@ -90,7 +90,7 @@ EXTERNAL         ::= --snacc isPdu:"TRUE" -- [UNIVERSAL 8] IMPLICIT SEQUENCE
         data-value-descriptor ObjectDescriptor OPTIONAL,
         encoding CHOICE
         {
-                single-ASN1-type [0] OCTET STRING,  -- should be ANY
+                single-ASN1-type [0] ANY,
                 octet-aligned    [1] IMPLICIT OCTET STRING,
                 arbitrary        [2] IMPLICIT BIT STRING
         }

--- a/cxx-lib/asn-useful.asn1
+++ b/cxx-lib/asn-useful.asn1
@@ -76,7 +76,7 @@ EXTERNAL         ::= --snacc isPdu:"TRUE" -- [UNIVERSAL 8] IMPLICIT SEQUENCE
         data-value-descriptor ObjectDescriptor OPTIONAL,
         encoding CHOICE
         {
-                single-ASN1-type [0] OCTET STRING,  -- should be ANY
+                single-ASN1-type [0] ANY,
                 octet-aligned    [1] IMPLICIT OCTET STRING,
                 arbitrary        [2] IMPLICIT BIT STRING
         }


### PR DESCRIPTION
From "ITU Recommendation X.208"

  34.4 The EXTERNAL type can be defined, using ASN.1, as follows:
  EXTERNAL ::= [UNIVERSAL 8] IMPLICIT SEQUENCE
  {direct-reference OBJECT IDENTIFIER OPTIONAL,
  indirect-reference INTEGER OPTIONAL,
  data-value-descriptor ObjectDescriptor OPTIONAL,
  encodingCHOICE
    {single-ASN1-type [0] ANY,
    octet-aligned [1] IMPLICIT OCTET STRING,
    arbitrary [2] IMPLICIT BIT STRING}}