### PR TITLE
Add include for nibble-alloc.h

### DIFF
--- a/c-examples/test-lib/test-lib.c
+++ b/c-examples/test-lib/test-lib.c
@@ -55,6 +55,7 @@
 #include "asn-incl.h"
 #include "sbuf.h"
 #include "exp-buf.h"
+#include "nibble-alloc.h"
 
 int TestAsnBuffers();
 int TestAsnTag();


### PR DESCRIPTION
To compile successfully with newer compilers.