### PR TITLE
Remove "Register" type

### DIFF
--- a/cxx-lib/src/hash.cpp
+++ b/cxx-lib/src/hash.cpp
@@ -122,7 +122,7 @@ _BEGIN_SNACC_NAMESPACE
 Hash
 MakeHash (const char *str, size_t len)
 {
-    register Hash n = 0;
+    Hash n = 0;
 
 #define HASHC   n = *str++ + 65587 * n
 


### PR DESCRIPTION
Newer compiler do not accept Register types in such places.